### PR TITLE
permit nickname to user table

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    end
 end


### PR DESCRIPTION
## WHAT
- avatorを投稿できるようにしたままだとエラーになるため、一時的にavator登録フォームを削除しnicknameだけ追加
## WHY
- デバイスで生成されるusersテーブルに画像を追加することを後回しにするため。